### PR TITLE
Handle listing tasks for any date

### DIFF
--- a/actions/list.go
+++ b/actions/list.go
@@ -26,7 +26,11 @@ func List(c *cli.Context) error {
 		return err
 	}
 
-	if c.Bool("prev") == true {
+	d := c.String("date")
+	
+	if len(d) > 0 {
+		dat, err = col.Date(d)
+	} else if (c.Bool("prev") == true) {
 		dat, err = col.Previous()
 	} else {
 		dat, err = col.Current()

--- a/commands/list.go
+++ b/commands/list.go
@@ -21,5 +21,9 @@ var List = cli.Command{
 			Name:  "prev",
 			Usage: "Show the previous day's tasks",
 		},
+		cli.StringFlag{
+			Name: "date",
+			Usage: "Show the date's tasks. E.g. \"2019-12-31\"",
+		},
 	},
 }

--- a/tasks/collection.go
+++ b/tasks/collection.go
@@ -137,6 +137,11 @@ func (c *Collection) currentTasks() (string, error) {
 	return c.fileToString(c.CurrFile)
 }
 
+func (c *Collection) dateTasks(d string) (string, error) {
+	fn := path.Join(c.Dir, fmt.Sprintf("%s.%s", d, fileExt))
+	return c.fileToString(fn)
+}
+
 func (c *Collection) previousTasks() (string, error) {
 	return c.fileToString(c.PrevFile)
 }
@@ -179,6 +184,16 @@ func (c *Collection) CurrentAndPrevious() (string, error) {
 		return "", err
 	}
 	return strings.Join([]string{prev, curr}, "\n\n"), nil
+}
+
+// Date returns the date's tasks
+func (c *Collection) Date(d string) (string, error) {
+	body, err := c.dateTasks(d)
+	if err != nil {
+		return "", err
+	}
+	title := generateTitle("Date", d)
+	return generateOutput(title, body), nil
 }
 
 // Previous returns the previous tasks


### PR DESCRIPTION
This update adds support for listing tasks from any arbitrary date. For example, `sup list --date 2019-03-31`.